### PR TITLE
Add support for device with communication key

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ yarn add zkteco-js
 const Zkteco = require("zkteco-js");
 
 const manageZktecoDevice = async () => {
-    const device = new Zkteco("192.168.1.106", 4370, 5200, 5000);
+    const device = new Zkteco("192.168.1.106", 4370, 5200, 5000, 1234);
 
     try {
         // Create socket connection to the device

--- a/index.js
+++ b/index.js
@@ -10,15 +10,16 @@ const ZUDP = require('./src/zudp')
 const {ZkError, ERROR_TYPES} = require('./src/exceptions/handler')
 
 class ZktecoJs {
-    constructor(ip, port, timeout, inport) {
+    constructor(ip, port, timeout, inport, comm_key = 0) {
         this.connectionType = null
 
-        this.ztcp = new ZTCP(ip, port, timeout)
+        this.ztcp = new ZTCP(ip, port, timeout, comm_key)
         this.zudp = new ZUDP(ip, port, timeout, inport)
         this.interval = null
         this.timer = null
         this.isBusy = false
         this.ip = ip
+        this.comm_key = comm_key
     }
 
     async functionWrapper(tcpCallback, udpCallback, command) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -10,7 +10,7 @@ const test = async () => {
     let zkInstance;
     try {
         // Create an instance of Zkteco with hard-coded values
-        zkInstance = new Zkteco('192.168.86.23', 4370, 10000, 4000);
+        zkInstance = new Zkteco('192.168.137.201', 4370, 10000, 4000, 5814);
         // Create socket to machine
         await zkInstance.createSocket();
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -10,7 +10,7 @@ const test = async () => {
     let zkInstance;
     try {
         // Create an instance of Zkteco with hard-coded values
-        zkInstance = new Zkteco('192.168.137.201', 4370, 10000, 4000, 5814);
+        zkInstance = new Zkteco('10.10.10.1', 4370, 10000, 4000, 1234);
         // Create socket to machine
         await zkInstance.createSocket();
 


### PR DESCRIPTION
## add support for device with communication code

i want to contribute with this. seems to be the same zklib repo but with async await instead of Promise. i already send the same PR to that repo. i tested locally with a Zkteco F22 model over TCP protocol and seems to work ok. i did not tested Realtime events yet.

Issue Resolves #3 