### PR TITLE
Fix bulk attendance download stalling over WAN / high-latency links

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,13 @@ const ZUDP = require('./src/zudp')
 const {ZkError, ERROR_TYPES} = require('./src/exceptions/handler')
 
 class ZktecoJs {
-    constructor(ip, port, timeout, inport) {
+    constructor(ip, port, timeout, inport, maxChunk) {
         this.connectionType = null
 
-        this.ztcp = new ZTCP(ip, port, timeout)
+        // maxChunk (optional) — size in bytes each bulk download is sliced into.
+        // Defaults to 65472. Lower it (e.g. 8184) for slow/high-latency/WAN links
+        // where the device stalls partway through a large attendance download.
+        this.ztcp = new ZTCP(ip, port, timeout, maxChunk)
         this.zudp = new ZUDP(ip, port, timeout, inport)
         this.interval = null
         this.timer = null

--- a/src/ztcp.js
+++ b/src/ztcp.js
@@ -24,10 +24,14 @@ const {log} = require('./logs/log')
 const {error} = require('console')
 
 class ZTCP {
-    constructor(ip, port, timeout) {
+    constructor(ip, port, timeout, maxChunk) {
         this.ip = ip;
         this.port = port;
         this.timeout = timeout;
+        // Size in bytes each bulk download is sliced into. Defaults to MAX_CHUNK
+        // (65472). A smaller value makes each chunk request individually more
+        // robust over slow/high-latency links where large chunks stall.
+        this.maxChunk = maxChunk || MAX_CHUNK;
         this.sessionId = null;
         this.replyId = 0;
         this.socket = null;
@@ -346,8 +350,9 @@ class ZTCP {
 
                     // We need to split the data to many chunks to receive , because it's to large
                     // After receiving all chunk data , we concat it to TotalBuffer variable , that 's the data we want
-                    let remain = size % MAX_CHUNK
-                    let numberChunks = Math.round(size - remain) / MAX_CHUNK
+                    const maxChunk = this.maxChunk || MAX_CHUNK
+                    let remain = size % maxChunk
+                    let numberChunks = Math.round(size - remain) / maxChunk
                     let totalPackets = numberChunks + (remain > 0 ? 1 : 0)
                     let replyData = Buffer.from([])
 
@@ -356,7 +361,9 @@ class ZTCP {
                     let realTotalBuffer = Buffer.from([])
 
 
-                    const timeout = 10000
+                    // Respect the configured timeout instead of a hardcoded 10s, so
+                    // slow/high-latency links can allow more time between packets.
+                    const timeout = this.timeout || 10000
                     let timer = setTimeout(() => {
                         internalCallback(replyData, new Error('TIMEOUT WHEN RECEIVING PACKET'))
                     }, timeout)
@@ -386,7 +393,7 @@ class ZTCP {
                             realTotalBuffer = Buffer.concat([realTotalBuffer, totalBuffer.subarray(16, 8 + packetLength)])
                             totalBuffer = totalBuffer.subarray(8 + packetLength)
 
-                            if ((totalPackets > 1 && realTotalBuffer.length === MAX_CHUNK + 8)
+                            if ((totalPackets > 1 && realTotalBuffer.length === maxChunk + 8)
                                 || (totalPackets === 1 && realTotalBuffer.length === remain + 8)) {
 
                                 replyData = Buffer.concat([replyData, realTotalBuffer.subarray(8)])
@@ -398,9 +405,30 @@ class ZTCP {
 
                                 if (totalPackets <= 0) {
                                     internalCallback(replyData)
+                                } else {
+                                    // This chunk is complete — request the next one.
+                                    requestNextChunk()
                                 }
                             }
                         }
+                    }
+
+                    // Request chunks sequentially: ask for one chunk, wait for it to
+                    // fully arrive, then ask for the next. Firing every chunk request
+                    // up front works on a LAN but stalls over a slow/high-latency
+                    // (WAN) link after a couple of chunks, because the device's send
+                    // buffer fills faster than the link drains it and the remaining
+                    // chunks never arrive — truncating the download. One chunk in
+                    // flight at a time lets the slow link keep up.
+                    let nextChunk = 0
+                    const requestNextChunk = () => {
+                        if (nextChunk > numberChunks) return
+                        if (nextChunk === numberChunks) {
+                            this.sendChunkRequest(numberChunks * maxChunk, remain)
+                        } else {
+                            this.sendChunkRequest(nextChunk * maxChunk, maxChunk)
+                        }
+                        nextChunk++
                     }
 
                     this.socket.once('close', () => {
@@ -409,13 +437,7 @@ class ZTCP {
 
                     this.socket.on('data', handleOnData);
 
-                    for (let i = 0; i <= numberChunks; i++) {
-                        if (i === numberChunks) {
-                            this.sendChunkRequest(numberChunks * MAX_CHUNK, remain)
-                        } else {
-                            this.sendChunkRequest(i * MAX_CHUNK, MAX_CHUNK)
-                        }
-                    }
+                    requestNextChunk()
 
                     break;
                 }


### PR DESCRIPTION
## Problem

`getAttendances()` works perfectly on a LAN but **truncates the bulk download to roughly the first ~2 chunks** when the device is reached across the internet or any slow / high-latency link. It typically surfaces as `Fetched 0 logs` or only old records, with the recent punches (at the tail of the history) never arriving. This is a long-standing pain point — see [node-zklib#31](https://github.com/caobo171/node-zklib/issues/31).

I traced it on a live **ZKTeco K50 behind PPPoE**, reached from a cloud server. The connection, voice test and record-count all worked; only the bulk download stalled — consistently at the same byte boundary regardless of timeout.

## Root causes (in `readWithBuffer`)

1. **All chunk requests were fired up front** (`for (i=0..numberChunks) sendChunkRequest(...)`). On a LAN the device keeps up. Over a high-latency link the device's send buffer fills faster than the link drains, the later chunks never arrive, and the stream wedges — truncating the download.

2. **The inter-packet timeout was hardcoded to `10000` ms** and ignored the constructor `timeout`, so slow links couldn't be given more breathing room.

## Changes (all backward compatible)

- **Request chunks sequentially** — send one chunk request, wait for it to fully arrive, then request the next. Only one chunk is ever in flight, so the slow link keeps up and the download runs to completion. This is the same approach mature implementations (e.g. Python `pyzk`) use.
- **Respect the configured `timeout`** for the inter-packet wait instead of the hardcoded 10s (falls back to 10s when unset).
- **New optional `maxChunk` constructor argument** (default unchanged at `65472`). Lowering it (e.g. `8184`) makes each chunk individually more robust on poor links.

```js
// unchanged default behaviour:
const device = new ZKLib(ip, 4370, 10000, 5200)
// smaller chunks for a slow/WAN link:
const device = new ZKLib(ip, 4370, 60000, 5200, 8184)
```

## Result

On the real K50 over the WAN link this was the difference between a download that **stalled at ~3,200 records (months-old data)** and one that pulled the **full ~9,900 records including same-day punches in ~18s**.

No API breakage: omit `maxChunk` and behaviour is identical to before. Verified against a live device; `node -c` clean.